### PR TITLE
Add TTS voiceover workflow

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,9 +71,10 @@
 
 ## 核心功能
 
-* **概念即影像**: 输入一个主题，Fogsight 将为您生成一部叙事完整的高水平动画，包含双语旁白与电影级的视觉质感。  
-* **智能编排**: Fogsight 的核心是其强大的LLM驱动的编排能力。从旁白、视觉元素到动态效果，AI 将自动完成整个创作流程，一气呵成。  
-* **语言用户界面 (LUI)**: 通过与 AI 的多轮对话，您可以对动画进行精准调优和迭代，直至达到您心中最理想的艺术效果。  
+* **概念即影像**: 输入一个主题，Fogsight 将为您生成一部叙事完整的高水平动画，包含双语旁白与电影级的视觉质感。
+* **智能编排**: Fogsight 的核心是其强大的LLM驱动的编排能力。从旁白、视觉元素到动态效果，AI 将自动完成整个创作流程，一气呵成。
+* **语言用户界面 (LUI)**: 通过与 AI 的多轮对话，您可以对动画进行精准调优和迭代，直至达到您心中最理想的艺术效果。
+* **一键生成配音**: 在动画播放器中点击“生成配音”，上传说话人参考音频后即可通过 TTS 服务生成旁白，并直接在线预览或下载。
 
 ## 快速上手
 
@@ -97,12 +98,14 @@
    pip install -r requirements.txt
    ```
 
-3. **配置API密钥:**
+3. **配置API密钥与配音服务:**
 
    ```bash
    cp demo-credentials.json credentials.json
    # 复制 demo-credentials.json 文件并重命名为 credentials.json
    # 编辑 credentials.json 文件，填入您的 API_KEY 和 BASE_URL。
+   # 若要启用“生成配音”按钮，请额外添加 TTS_BASE_URL 指向运行中的 tts.py 服务，例如：
+   # "TTS_BASE_URL": "http://127.0.0.1:9000"
    # **请注意**，我们使用的是与 OpenAI 兼容的 SDK，但您仍应使用Gemini 2.5 pro
    ```
 
@@ -130,7 +133,7 @@
    cd fogsight
    ```
 
-3. **配置API密钥:**
+3. **配置API密钥（可选配置配音服务）:**
    ```bash
    cp demo-credentials.json credentials.json
    # 编辑 credentials.json 文件，填入您的 API_KEY、BASE_URL 和 MODEL
@@ -148,6 +151,7 @@
    #   "BASE_URL": "",
    #   "MODEL": "gemini-2.5-pro"
    # }
+   # 如果需要在容器内启用配音按钮，可同时设置 TTS_BASE_URL 指向运行 tts.py 的地址
    ```
 
 4. **使用 Docker Compose 启动:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jinja2
 pytz
 google-genai
 requests
+httpx

--- a/static/style.css
+++ b/static/style.css
@@ -115,10 +115,16 @@ button:disabled {
 .player-container { background: var(--bubble-agent-bg); border-radius: var(--radius-lg); padding: 8px; }
 .iframe-wrapper { aspect-ratio: 16 / 9; width: 100%; max-width: calc(80vh * 16 / 9); max-height: 80vh; margin: 0 auto; border-radius: 12px; overflow: hidden; display: block; }
 .animation-iframe { width: 100%; height: 100%; border: none; }
-.player-actions { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; padding: 10px 4px 4px; }
+.player-actions { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; padding: 10px 4px 4px; }
 .action-button { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 10px; border: none; border-radius: 10px; font-size: 0.9rem; font-weight: 500; cursor: pointer; background: rgba(0,0,0,0.05); transition: background-color 0.2s; }
 .action-button:hover { background: rgba(0,0,0,0.1); }
 .action-button.open-new-window { background: rgba(10, 132, 255, 0.15); color: #0A84FF; }
+.action-button:disabled { cursor: not-allowed; opacity: 0.6; }
+
+.voiceover-container { margin-top: 12px; background: rgba(255,255,255,0.6); border-radius: var(--radius-md); padding: 12px; display: flex; align-items: center; justify-content: center; min-height: 56px; border: 1px dashed var(--border-color); }
+.voiceover-container audio { width: 100%; }
+.voiceover-placeholder { margin: 0; color: var(--text-secondary); font-size: 0.9rem; text-align: center; }
+.voiceover-container.empty { background: rgba(255,255,255,0.4); }
 
 /* === 动画占位符 === */
 .animated-placeholder { position: absolute; top: 0; left: 25px; height: 60px; width: calc(100% - 85px); display: flex; align-items: center; overflow: hidden; pointer-events: none; }
@@ -204,6 +210,18 @@ button:disabled {
 .modal-close-button:hover {
     color: var(--text-secondary);
 }
+
+.voiceover-modal-content { max-width: 520px; text-align: left; }
+.voiceover-modal-content h2 { margin-top: 0; font-size: 1.4rem; }
+.voiceover-field { display: flex; flex-direction: column; gap: 6px; text-align: left; margin-bottom: 1rem; }
+.voiceover-field span { font-size: 0.95rem; font-weight: 500; color: var(--text-secondary); }
+.voiceover-field textarea,
+.voiceover-field input[type="file"] { width: 100%; border: 1px solid var(--border-color); border-radius: var(--radius-sm); padding: 10px; font-family: var(--font-sans); font-size: 0.95rem; box-sizing: border-box; }
+.voiceover-field textarea { resize: vertical; min-height: 90px; }
+.voiceover-field.optional span { font-weight: 400; }
+.voiceover-status { min-height: 1.2rem; font-size: 0.9rem; color: var(--text-secondary); margin: 0 0 1rem 0; transition: color 0.2s; }
+.voiceover-status.error { color: #D8000C; }
+.voiceover-status.success { color: #1a7f37; }
 
 /* 遮罩层 */
 .overlay {

--- a/templates/index.html
+++ b/templates/index.html
@@ -118,10 +118,21 @@
                         <svg viewBox="0 0 24 24"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
                         <span data-translate-key="saveAsHTML">保存为 HTML</span>
                     </button>
+                    <button class="action-button generate-voiceover">
+                        <svg viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8a5 5 0 0 1 0 8" /><path d="M19 5a9 9 0 0 1 0 14" /><path d="M5 15v-6a1 1 0 0 1 1.555 -.832l4.445 3.832v.001a1 1 0 0 1 0 1.598l-4.445 3.401v.001a1 1 0 0 1 -1.555 -.832" /></svg>
+                        <span data-translate-key="generateVoiceover">生成配音</span>
+                    </button>
+                    <button class="action-button download-voiceover" disabled>
+                        <svg viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2" /><path d="M7 11l5 5l5 -5" /><path d="M12 4l0 12" /></svg>
+                        <span data-translate-key="downloadVoiceover">下载配音</span>
+                    </button>
                     <button class="action-button export-video">
                         <svg viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 10l4.553 -2.276a1 1 0 0 1 1.447 .894v6.764a1 1 0 0 1 -1.447 .894l-4.553 -2.276v-4z" /><path d="M3 6m0 2a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v8a2 2 0 0 1 -2 2h-8a2 2 0 0 1 -2 -2z" /></svg>
                         <span data-translate-key="exportAsVideo">导出为视频</span>
                     </button>
+                </div>
+                <div class="voiceover-container empty">
+                    <p class="voiceover-placeholder" data-translate-key="voiceoverPlaceholder">生成的配音将在这里显示</p>
                 </div>
             </div>
         </div>
@@ -132,6 +143,30 @@
             <button id="modal-close-button" class="modal-close-button" title="Close">×</button>
             <p data-translate-key="featureComingSoon">该功能正在开发中...</p>
             <button id="modal-github-button" class="modal-button" data-translate-key="visitGitHub">访问 GitHub</button>
+        </div>
+    </div>
+
+    <div id="voiceover-modal" class="modal-overlay">
+        <div class="modal-content voiceover-modal-content">
+            <button id="voiceover-close-button" class="modal-close-button" title="Close">×</button>
+            <h2 data-translate-key="voiceoverModalTitle">生成动画配音</h2>
+            <p data-translate-key="voiceoverModalDescription">输入旁白文本并上传说话人参考音频，系统会调用 TTS 服务生成配音。</p>
+            <form id="voiceover-form">
+                <label class="voiceover-field">
+                    <span data-translate-key="voiceoverTextLabel">旁白文本</span>
+                    <textarea id="voiceover-text" rows="4" required></textarea>
+                </label>
+                <label class="voiceover-field">
+                    <span data-translate-key="voiceoverVoiceLabel">说话人参考音频</span>
+                    <input id="voiceover-speaker" type="file" accept="audio/*" required>
+                </label>
+                <label class="voiceover-field optional">
+                    <span data-translate-key="voiceoverEmotionLabel">情感参考音频（可选）</span>
+                    <input id="voiceover-emo" type="file" accept="audio/*">
+                </label>
+                <p id="voiceover-status" class="voiceover-status"></p>
+                <button id="voiceover-submit-button" type="submit" class="modal-button" data-translate-key="voiceoverGenerateButton">开始生成</button>
+            </form>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add a FastAPI `/voiceover` proxy that forwards narration requests to a configurable TTS service and enable the dependency
- extend the animation player UI with voiceover controls plus a modal to submit narration text and speaker audio
- document the new voiceover workflow and configuration in the README

## Testing
- python -m compileall app.py static/script.js templates/index.html

------
https://chatgpt.com/codex/tasks/task_b_68ce9eb5f34483269e8dfd58b33e47a2