### PR TITLE
Add automatic Chinese voiceover generation

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -125,6 +125,11 @@ button:disabled {
 .voiceover-container audio { width: 100%; }
 .voiceover-placeholder { margin: 0; color: var(--text-secondary); font-size: 0.9rem; text-align: center; }
 .voiceover-container.empty { background: rgba(255,255,255,0.4); }
+.voiceover-container.loading { background: rgba(255,255,255,0.7); border-style: solid; border-color: rgba(10, 132, 255, 0.2); }
+.voiceover-container.loading .voiceover-placeholder { color: #0A84FF; }
+.voiceover-container.error { background: #FFF5F5; border-style: solid; border-color: #FFB3B3; }
+.voiceover-container.error .voiceover-placeholder { color: #D8000C; }
+.voiceover-container.success { background: #F3FFF6; border-style: solid; border-color: #A3E9C5; }
 
 /* === 动画占位符 === */
 .animated-placeholder { position: absolute; top: 0; left: 25px; height: 60px; width: calc(100% - 85px); display: flex; align-items: center; overflow: hidden; pointer-events: none; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -118,9 +118,9 @@
                         <svg viewBox="0 0 24 24"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
                         <span data-translate-key="saveAsHTML">保存为 HTML</span>
                     </button>
-                    <button class="action-button generate-voiceover">
+                    <button class="action-button generate-voiceover" disabled>
                         <svg viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8a5 5 0 0 1 0 8" /><path d="M19 5a9 9 0 0 1 0 14" /><path d="M5 15v-6a1 1 0 0 1 1.555 -.832l4.445 3.832v.001a1 1 0 0 1 0 1.598l-4.445 3.401v.001a1 1 0 0 1 -1.555 -.832" /></svg>
-                        <span data-translate-key="generateVoiceover">生成配音</span>
+                        <span data-translate-key="voiceoverAutoGenerating">自动配音生成中...</span>
                     </button>
                     <button class="action-button download-voiceover" disabled>
                         <svg viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2" /><path d="M7 11l5 5l5 -5" /><path d="M12 4l0 12" /></svg>


### PR DESCRIPTION
## Summary
- add configuration hooks and a new /voiceover/auto endpoint that reuses the shared TTS proxy with default speaker audio
- teach the front-end to extract Chinese narration from generated HTML, auto-call the new endpoint, and update UI copy/states accordingly
- refresh styling and button text so the voiceover panel reflects automatic generation status instead of manual workflow

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_b_68ceadb0598483268d1ccabc0a5e11b8