### PR TITLE
Add video export endpoint and frontend workflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pytz
 google-genai
 requests
 httpx
+playwright
+python-multipart


### PR DESCRIPTION
## Summary
- add frontend video export workflow that sends animation HTML and optional voiceover audio to the backend and downloads the resulting MP4
- introduce reusable helpers for updating export labels, collecting voiceover audio, and parsing backend errors in the player UI
- implement FastAPI /export endpoint using Playwright and ffmpeg to capture frames, mux optional audio, and stream the MP4; declare new dependencies

## Testing
- `python -m compileall app.py`


------
https://chatgpt.com/codex/tasks/task_b_68d0c9abdfe8832684f54db3669f536a