### PR TITLE
Normalize voiceover text before calling TTS

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,6 +131,8 @@ _DURATION_PATTERN = re.compile(
 _MS_KEYWORDS = ("毫秒", "millisecond", "milliseconds", "durationms", "duration_ms", "duration-ms")
 _MS_DIGIT_PATTERN = re.compile(r"\d\s*ms\b", re.IGNORECASE)
 
+_CHINESE_CHAR_PATTERN = re.compile(r"[\u3400-\u9fff]")
+
 
 def _normalize_duration_value(
     numeric: float,
@@ -182,6 +184,39 @@ def _coerce_positive_float(value: Any) -> Optional[float]:
                 unit = match.group("unit")
                 return _normalize_duration_value(numeric, unit=unit, original_text=stripped)
     return None
+
+
+def _normalize_voiceover_text(text: str) -> str:
+    """Sanitize narration text before sending it to the TTS backend.
+
+    The TTS backend occasionally stops reading after the first line when the
+    payload contains hard line breaks.  We collapse multiple lines into a
+    single string while keeping natural sentence boundaries so the generated
+    audio covers the full narration.
+    """
+
+    if not text:
+        return ""
+
+    # Normalise newlines first so we can split reliably.
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    segments = []
+    for raw_segment in normalized.split("\n"):
+        stripped = raw_segment.strip()
+        if not stripped:
+            continue
+        collapsed = re.sub(r"\s+", " ", stripped)
+        if not collapsed:
+            continue
+
+        if collapsed[-1] in "。！？?.!":
+            segments.append(collapsed)
+        elif _CHINESE_CHAR_PATTERN.search(collapsed):
+            segments.append(collapsed + "。")
+        else:
+            segments.append(collapsed)
+
+    return " ".join(segments)
 
 
 async def _probe_stream_duration(path: Path, stream_selector: str) -> Optional[float]:
@@ -547,9 +582,13 @@ async def _forward_tts_request(
     if not text or not text.strip():
         raise HTTPException(status_code=400, detail="Text for voiceover cannot be empty.")
 
+    sanitized_text = _normalize_voiceover_text(text)
+    if not sanitized_text:
+        raise HTTPException(status_code=400, detail="Voiceover text could not be processed.")
+
     tts_endpoint = _get_tts_endpoint()
 
-    data: Dict[str, Any] = {"text": text}
+    data: Dict[str, Any] = {"text": sanitized_text}
     if TTS_DEFAULT_PARAMETERS:
         data.update(TTS_DEFAULT_PARAMETERS)
 

--- a/tests/test_durations.py
+++ b/tests/test_durations.py
@@ -12,7 +12,7 @@ if str(ROOT) not in sys.path:
 os.environ.setdefault("FOGSIGHT_API_KEY", "test-key")
 os.environ.setdefault("FOGSIGHT_CREDENTIALS_PATH", str(ROOT / "demo-credentials.json"))
 
-from app import _coerce_positive_float
+from app import _coerce_positive_float, _normalize_voiceover_text
 
 
 @pytest.mark.parametrize(
@@ -49,3 +49,13 @@ def test_coerce_positive_float(raw, expected):
 def test_values_without_units_remain_seconds():
     assert _coerce_positive_float(90) == pytest.approx(90.0)
     assert _coerce_positive_float("42") == pytest.approx(42.0)
+
+
+def test_normalize_voiceover_text_collapses_lines():
+    text = "第一句。\n第二句\n\n第三句\r\nFinally, an English line"
+    normalized = _normalize_voiceover_text(text)
+    assert "第一句。" in normalized
+    assert "第二句。" in normalized
+    assert "第三句。" in normalized
+    assert "Finally, an English line" in normalized
+    assert "\n" not in normalized


### PR DESCRIPTION
## Summary
- sanitize narration text before forwarding to the TTS proxy so multi-line input no longer stalls after the first sentence
- add regression test ensuring the sanitizer collapses line breaks while preserving content

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d2549691c88326a319702f4cffc0c4