### PR TITLE
Prevent ffmpeg export hang when muxing audio

### DIFF
--- a/tests/test_durations.py
+++ b/tests/test_durations.py
@@ -12,7 +12,7 @@ if str(ROOT) not in sys.path:
 os.environ.setdefault("FOGSIGHT_API_KEY", "test-key")
 os.environ.setdefault("FOGSIGHT_CREDENTIALS_PATH", str(ROOT / "demo-credentials.json"))
 
-from app import _coerce_positive_float
+from app import _coerce_positive_float, _normalize_voiceover_text, _plan_audio_muxing
 
 
 @pytest.mark.parametrize(
@@ -49,3 +49,30 @@ def test_coerce_positive_float(raw, expected):
 def test_values_without_units_remain_seconds():
     assert _coerce_positive_float(90) == pytest.approx(90.0)
     assert _coerce_positive_float("42") == pytest.approx(42.0)
+
+
+def test_normalize_voiceover_text_collapses_lines():
+    text = "第一句。\n第二句\n\n第三句\r\nFinally, an English line"
+    normalized = _normalize_voiceover_text(text)
+    assert "第一句。" in normalized
+    assert "第二句。" in normalized
+    assert "第三句。" in normalized
+    assert "Finally, an English line" in normalized
+    assert "\n" not in normalized
+
+
+@pytest.mark.parametrize(
+    "video_duration, audio_duration, expected_filters, expected_shortest",
+    [
+        (13.26, 12.76, ["apad"], True),
+        (10.0, 12.5, [], True),
+        (10.0, 10.0, [], False),
+        (10.0, 9.9, ["apad"], True),
+        (None, 12.0, ["apad"], True),
+        (10.0, None, ["apad"], True),
+    ],
+)
+def test_plan_audio_muxing(video_duration, audio_duration, expected_filters, expected_shortest):
+    filters, include_shortest = _plan_audio_muxing(video_duration, audio_duration)
+    assert filters == expected_filters
+    assert include_shortest is expected_shortest


### PR DESCRIPTION
## Summary
- add a helper that determines the appropriate ffmpeg audio filters and flags based on detected stream durations
- ensure we always stop muxing when padding audio, preventing exports from stalling when the recorded video duration cannot be probed
- extend the duration test suite to cover the new muxing planner logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d2549691c88326a319702f4cffc0c4