### PR TITLE
Add toggle to control automatic voiceover generation

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -39,6 +39,9 @@ document.addEventListener('DOMContentLoaded', () => {
         errorTooManyRequests: {zh: "今天已经使用太多，请明天再试", en: "Too many requests today. Please try again tomorrow."},
         errorLLMParseError: {zh: "返回的动画代码解析失败，请调整提示词重新生成。", en: "Failed to parse the returned animation code. Please adjust your prompt and try again."},
         voiceoverPlaceholder: { zh: "生成的配音将在这里显示", en: "Generated voiceover will appear here." },
+        voiceoverToggleLabel: { zh: "自动配音", en: "Auto voiceover" },
+        voiceoverToggleOn: { zh: "开启", en: "On" },
+        voiceoverToggleOff: { zh: "关闭", en: "Off" },
         voiceoverAutoGenerating: { zh: "自动配音生成中...", en: "Generating Chinese voiceover..." },
         voiceoverAutoReady: { zh: "自动配音已生成", en: "Chinese voiceover ready" },
         voiceoverAutoFailed: { zh: "自动配音失败", en: "Auto voiceover failed." },
@@ -81,6 +84,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const voiceoverEmotionInput = document.getElementById('voiceover-emo');
     const voiceoverStatus = document.getElementById('voiceover-status');
     const voiceoverSubmitButton = document.getElementById('voiceover-submit-button');
+    const voiceoverToggle = document.getElementById('voiceover-toggle');
+    const voiceoverToggleStateLabel = document.getElementById('voiceover-toggle-state');
+
+    const VOICEOVER_PREFERENCE_KEY = 'voiceoverAutoEnabled';
 
     const templates = {
         user: document.getElementById('user-message-template'),
@@ -103,11 +110,29 @@ document.addEventListener('DOMContentLoaded', () => {
     let placeholderInterval;
     let activeVoiceoverPlayer = null;
     let activeVoiceoverTopic = '';
+    let autoVoiceoverEnabled = true;
 
     function resetVoiceoverStatus() {
         if (!voiceoverStatus) return;
         voiceoverStatus.textContent = '';
         voiceoverStatus.className = 'voiceover-status';
+    }
+
+    function updateVoiceoverToggleState() {
+        if (voiceoverToggle) {
+            voiceoverToggle.setAttribute('aria-checked', autoVoiceoverEnabled ? 'true' : 'false');
+            const toggleLabel = translations.voiceoverToggleLabel?.[currentLang] || 'Auto voiceover';
+            voiceoverToggle.setAttribute('aria-label', toggleLabel);
+            voiceoverToggle.title = toggleLabel;
+        }
+        if (voiceoverToggleStateLabel) {
+            const key = autoVoiceoverEnabled ? 'voiceoverToggleOn' : 'voiceoverToggleOff';
+            voiceoverToggleStateLabel.dataset.translateKey = key;
+            const translation = translations[key]?.[currentLang];
+            if (translation) {
+                voiceoverToggleStateLabel.textContent = translation;
+            }
+        }
     }
 
     function setVoiceoverButtonTranslation(button, key) {
@@ -143,6 +168,13 @@ document.addEventListener('DOMContentLoaded', () => {
         placeholder.textContent = message;
         container.innerHTML = '';
         container.appendChild(placeholder);
+    }
+
+    function enableManualVoiceoverButton(button) {
+        if (!button) return;
+        button.disabled = false;
+        button.classList.remove('disabled');
+        setVoiceoverButtonTranslation(button, 'generateVoiceover');
     }
 
     function extractChineseNarrationFromHtml(htmlContent) {
@@ -251,6 +283,12 @@ document.addEventListener('DOMContentLoaded', () => {
     async function autoGenerateVoiceoverForPlayer(playerElement, htmlContent, topic) {
         if (!playerElement) return;
         const voiceoverButton = playerElement.querySelector('.generate-voiceover');
+
+        if (!autoVoiceoverEnabled) {
+            enableManualVoiceoverButton(voiceoverButton);
+            return;
+        }
+
         setVoiceoverButtonTranslation(voiceoverButton, 'voiceoverAutoGenerating');
         if (voiceoverButton) {
             voiceoverButton.disabled = true;
@@ -262,7 +300,13 @@ document.addEventListener('DOMContentLoaded', () => {
         const narrationText = extractChineseNarrationFromHtml(htmlContent);
         if (!narrationText) {
             updateVoiceoverStatus(playerElement, 'voiceoverAutoSubtitleMissing', 'error');
-            setVoiceoverButtonTranslation(voiceoverButton, 'voiceoverAutoFailed');
+            const warningMessage = translations.voiceoverAutoSubtitleMissing?.[currentLang]
+                || translations.voiceoverAutoFailed?.[currentLang]
+                || '';
+            if (warningMessage) {
+                showWarning(warningMessage);
+            }
+            enableManualVoiceoverButton(voiceoverButton);
             return;
         }
 
@@ -283,8 +327,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (errorBody) errorMessage = errorBody;
                 }
                 updateVoiceoverStatus(playerElement, null, 'error', errorMessage);
-                setVoiceoverButtonTranslation(voiceoverButton, 'voiceoverAutoFailed');
                 showWarning(errorMessage);
+                enableManualVoiceoverButton(voiceoverButton);
                 return;
             }
 
@@ -297,8 +341,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 || translations.voiceoverAutoFailed[currentLang]
                 || 'Voiceover service is unavailable.';
             updateVoiceoverStatus(playerElement, null, 'error', fallbackMessage);
-            setVoiceoverButtonTranslation(voiceoverButton, 'voiceoverAutoFailed');
             showWarning(fallbackMessage);
+            enableManualVoiceoverButton(voiceoverButton);
         }
     }
 
@@ -594,6 +638,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         const node = templates.player.content.cloneNode(true);
         const playerElement = node.firstElementChild;
+        playerElement.dataset.topic = topic || '';
         playerElement.querySelectorAll('[data-translate-key]').forEach(el => {
             const key = el.dataset.translateKey;
             el.textContent = translations[key]?.[currentLang] || el.textContent;
@@ -616,9 +661,19 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         const voiceoverButton = playerElement.querySelector('.generate-voiceover');
         if (voiceoverButton) {
-            voiceoverButton.disabled = true;
-            voiceoverButton.classList.add('disabled');
-            setVoiceoverButtonTranslation(voiceoverButton, 'voiceoverAutoGenerating');
+            voiceoverButton.addEventListener('click', () => {
+                if (voiceoverButton.disabled) return;
+                openVoiceoverModal(playerElement, topic);
+            });
+            if (autoVoiceoverEnabled) {
+                voiceoverButton.disabled = true;
+                voiceoverButton.classList.add('disabled');
+                setVoiceoverButtonTranslation(voiceoverButton, 'voiceoverAutoGenerating');
+            } else {
+                voiceoverButton.disabled = false;
+                voiceoverButton.classList.remove('disabled');
+                setVoiceoverButtonTranslation(voiceoverButton, 'generateVoiceover');
+            }
         }
         const downloadVoiceoverButton = playerElement.querySelector('.download-voiceover');
         if (downloadVoiceoverButton) {
@@ -719,9 +774,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         chatLog.appendChild(playerElement);
         scrollToBottom();
-        autoGenerateVoiceoverForPlayer(playerElement, htmlContent, topic).catch((error) => {
-            console.error('Auto voiceover generation encountered an unexpected error:', error);
-        });
+        if (autoVoiceoverEnabled) {
+            autoGenerateVoiceoverForPlayer(playerElement, htmlContent, topic).catch((error) => {
+                console.error('Auto voiceover generation encountered an unexpected error:', error);
+            });
+        }
     }
 
     function isHtmlContentValid(htmlContent) {
@@ -780,6 +837,14 @@ document.addEventListener('DOMContentLoaded', () => {
         languageSwitcher.querySelectorAll('button').forEach(btn => {
             btn.classList.toggle('active', btn.dataset.lang === lang);
         });
+        if (voiceoverToggle) {
+            const toggleLabel = translations.voiceoverToggleLabel?.[lang];
+            if (toggleLabel) {
+                voiceoverToggle.setAttribute('aria-label', toggleLabel);
+                voiceoverToggle.title = toggleLabel;
+            }
+        }
+        updateVoiceoverToggleState();
         startPlaceholderAnimation();
         localStorage.setItem('preferredLanguage', lang);
     }
@@ -802,6 +867,22 @@ document.addEventListener('DOMContentLoaded', () => {
             const target = e.target.closest('button');
             if (target) setLanguage(target.dataset.lang);
         });
+
+        if (voiceoverToggle) {
+            const storedPreference = localStorage.getItem(VOICEOVER_PREFERENCE_KEY);
+            if (storedPreference !== null) {
+                autoVoiceoverEnabled = storedPreference === 'true';
+            }
+            voiceoverToggle.checked = autoVoiceoverEnabled;
+            updateVoiceoverToggleState();
+            voiceoverToggle.addEventListener('change', () => {
+                autoVoiceoverEnabled = voiceoverToggle.checked;
+                localStorage.setItem(VOICEOVER_PREFERENCE_KEY, String(autoVoiceoverEnabled));
+                updateVoiceoverToggleState();
+            });
+        } else {
+            autoVoiceoverEnabled = true;
+        }
 
         function hideModal() {
             featureModal.classList.remove('visible');

--- a/static/style.css
+++ b/static/style.css
@@ -74,7 +74,18 @@ button:disabled {
 .initial-footer span { color: var(--border-color); }
 
 
-.chat-header { padding: 0.75rem 1.5rem; border-bottom: 1px solid var(--border-color); background: rgba(255,255,255,0.7); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); display: flex; align-items: center; justify-content: space-between; }
+.chat-header { padding: 0.75rem 1.5rem; border-bottom: 1px solid var(--border-color); background: rgba(255,255,255,0.7); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.chat-header-left, .chat-header-right { display: flex; align-items: center; gap: 1rem; }
+.chat-header-right { justify-content: flex-end; }
+.voiceover-toggle { display: inline-flex; align-items: center; gap: 0.75rem; background: var(--bubble-agent-bg); border-radius: 999px; padding: 6px 12px; }
+.voiceover-toggle-label { font-size: 0.85rem; font-weight: 500; color: var(--text-secondary); }
+.voiceover-toggle-control { position: relative; width: 46px; height: 26px; display: inline-flex; align-items: center; cursor: pointer; }
+.voiceover-toggle-control input { opacity: 0; width: 0; height: 0; }
+.voiceover-toggle-slider { position: absolute; inset: 0; background: rgba(0,0,0,0.15); border-radius: 999px; transition: background 0.2s ease; cursor: pointer; }
+.voiceover-toggle-slider::before { content: ""; position: absolute; top: 3px; left: 3px; width: 20px; height: 20px; border-radius: 50%; background: #fff; box-shadow: 0 2px 6px rgba(0,0,0,0.15); transition: transform 0.2s ease; }
+.voiceover-toggle-control input:checked + .voiceover-toggle-slider { background: #0A84FF; }
+.voiceover-toggle-control input:checked + .voiceover-toggle-slider::before { transform: translateX(20px); }
+.voiceover-toggle-state { font-size: 0.85rem; font-weight: 500; color: var(--text-secondary); min-width: 2.5em; text-align: center; }
 #logo-chat { display: none; }
 .new-chat-button { background: var(--bubble-agent-bg); color: var(--text-primary); border: none; border-radius: 8px; padding: 8px 12px; display: inline-flex; align-items: center; gap: 8px; font-size: 0.9rem; font-weight: 500; cursor: pointer; }
 .chat-log { flex-grow: 1; overflow-y: auto; padding: 1.5rem; display: flex; flex-direction: column; gap: 1.25rem; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,11 +47,23 @@
 
     <div id="chat-view" class="chat-view">
         <header class="chat-header">
-            <button id="new-chat-button" class="new-chat-button" data-translate-key="newChatTitle" title="新对话">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
-                <span data-translate-key="newChat">新对话</span>
-            </button>
-            <img src="/static/logo.png" alt="Studio Logo" class="logo" id="logo-chat">
+            <div class="chat-header-left">
+                <button id="new-chat-button" class="new-chat-button" data-translate-key="newChatTitle" title="新对话">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+                    <span data-translate-key="newChat">新对话</span>
+                </button>
+            </div>
+            <div class="chat-header-right">
+                <div class="voiceover-toggle" role="group" aria-labelledby="voiceover-toggle-label">
+                    <span id="voiceover-toggle-label" class="voiceover-toggle-label" data-translate-key="voiceoverToggleLabel">自动配音</span>
+                    <label class="voiceover-toggle-control">
+                        <input type="checkbox" id="voiceover-toggle" role="switch" aria-checked="true">
+                        <span class="voiceover-toggle-slider"></span>
+                    </label>
+                    <span id="voiceover-toggle-state" class="voiceover-toggle-state" data-translate-key="voiceoverToggleOn">开启</span>
+                </div>
+                <img src="/static/logo.png" alt="Studio Logo" class="logo" id="logo-chat">
+            </div>
         </header>
         <main id="chat-log" class="chat-log"></main>
         <footer class="chat-footer">


### PR DESCRIPTION
## Summary
- add a chat header toggle so users can enable or disable automatic voiceover generation
- persist the preferred voiceover setting and update the generation workflow to respect it, including falling back to manual voiceover when auto generation fails
- style the new toggle control to match the existing interface

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f5ced5a19c8326b8a2a4b33bd6a8fd